### PR TITLE
Fix error with imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-glamorous-displayname",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "add a displayName property to glamorous components",
   "keywords": [
     "babel",

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,12 @@ export default function (babel) {
           return
         }
         const {id: {name}} = node
-        const {referencePaths} = path.scope.getBinding(name)
-        referencePaths.forEach(reference => {
-          identifiers.add(reference)
-        })
+        if(path.scope.getBinding(name)){
+          const {referencePaths} = path.scope.getBinding(name)
+          referencePaths.forEach(reference => {
+            identifiers.add(reference)
+          })
+        }
       },
       Program: {
         exit(path) {


### PR DESCRIPTION
I think this might be a result of my own lack of understanding of babel/webpack (time to watch that FEM course 😓) but for some reason, when using an import statement, `!isRequireCall(node.init)`  (from the `VariableDeclarator` pattern) evaluates to false even though there is no `require` present in the file and thus doesn't return. I'm also not sure if it's because the `import` is being converted into `require` by a preset before this plugins runs - Babel docs say plugins should run before presets. Anyway, it ends up running `path.scope.getBinding(name)`, but says `referencePaths` is undefined and throws an error:
![image](https://cloud.githubusercontent.com/assets/16327281/25267567/42fc0816-2643-11e7-94ff-14ce690d2fc9.png)

Wrapping that code in an if statement seems like a hacky solution but it appears to work regardless of `require`/`import`. Is there a better way to solve this?